### PR TITLE
Fix base url so RSS feed is generated properly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ email: bartkali@gmail.com
 description: > # this means to ignore newlines until "baseurl:"
   Software engineering blog
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "" # the base hostname & protocol for your site, e.g. http://example.com
+url: "https://bartekkalinka.github.io" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: bartkali
 github_username:  bartekkalinka
 disqus:


### PR DESCRIPTION
Your rss entries do not have proper full url to the articles and JVM Bloggers can't get your blog url. Please compare your feedEntry value here https://bartekkalinka.github.io/feed.xml with one here https://mateuszrasinski.github.io/feed.xml .

If you set `url` value properly, next time your RSS should be "more" valid :)